### PR TITLE
remove unnecessary check for isAvailableForServiceType

### DIFF
--- a/iOS/KDSocialShare.m
+++ b/iOS/KDSocialShare.m
@@ -18,45 +18,40 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(tweet:(NSDictionary *)options
                   callback: (RCTResponseSenderBlock)callback)
 {
-  if([SLComposeViewController isAvailableForServiceType:SLServiceTypeTwitter]) {
-    NSString *serviceType = SLServiceTypeTwitter;
-    SLComposeViewController *composeCtl = [SLComposeViewController composeViewControllerForServiceType:serviceType];
+  NSString *serviceType = SLServiceTypeTwitter;
+  SLComposeViewController *composeCtl = [SLComposeViewController composeViewControllerForServiceType:serviceType];
 
-    if ([options objectForKey:@"link"] && [options objectForKey:@"link"] != [NSNull null]) {
-      NSString *link = [RCTConvert NSString:options[@"link"]];
-      [composeCtl addURL:[NSURL URLWithString:link]];
-    }
-
-    if ([options objectForKey:@"image"] && [options objectForKey:@"image"] != [NSNull null]) {
-      [composeCtl addImage: [UIImage imageNamed: options[@"image"]]];
-    } else if ([options objectForKey:@"imagelink"] && [options objectForKey:@"imagelink"] != [NSNull null]) {
-      NSString *imagelink = [RCTConvert NSString:options[@"imagelink"]];
-      UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:imagelink]]];
-      [composeCtl addImage:image];
-    }
-
-    if ([options objectForKey:@"text"] && [options objectForKey:@"text"] != [NSNull null]) {
-      NSString *text = [RCTConvert NSString:options[@"text"]];
-      [composeCtl setInitialText:text];
-    }
-
-    [composeCtl setCompletionHandler:^(SLComposeViewControllerResult result) {
-      if (result == SLComposeViewControllerResultDone) {
-        // Sent
-        callback(@[@"success"]);
-      }
-      else if (result == SLComposeViewControllerResultCancelled){
-        // Cancelled
-        callback(@[@"cancelled"]);
-      }
-    }];
-
-    UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
-    [ctrl presentViewController:composeCtl animated:YES completion: nil];
+  if ([options objectForKey:@"link"] && [options objectForKey:@"link"] != [NSNull null]) {
+    NSString *link = [RCTConvert NSString:options[@"link"]];
+    [composeCtl addURL:[NSURL URLWithString:link]];
   }
-  else{
-    callback(@[@"not_available"]);
+
+  if ([options objectForKey:@"image"] && [options objectForKey:@"image"] != [NSNull null]) {
+    [composeCtl addImage: [UIImage imageNamed: options[@"image"]]];
+  } else if ([options objectForKey:@"imagelink"] && [options objectForKey:@"imagelink"] != [NSNull null]) {
+    NSString *imagelink = [RCTConvert NSString:options[@"imagelink"]];
+    UIImage *image = [UIImage imageWithData:[NSData dataWithContentsOfURL:[NSURL URLWithString:imagelink]]];
+    [composeCtl addImage:image];
   }
+
+  if ([options objectForKey:@"text"] && [options objectForKey:@"text"] != [NSNull null]) {
+    NSString *text = [RCTConvert NSString:options[@"text"]];
+    [composeCtl setInitialText:text];
+  }
+
+  [composeCtl setCompletionHandler:^(SLComposeViewControllerResult result) {
+    if (result == SLComposeViewControllerResultDone) {
+      // Sent
+      callback(@[@"success"]);
+    }
+    else if (result == SLComposeViewControllerResultCancelled){
+      // Cancelled
+      callback(@[@"cancelled"]);
+    }
+  }];
+
+  UIViewController *ctrl = [[[[UIApplication sharedApplication] delegate] window] rootViewController];
+  [ctrl presentViewController:composeCtl animated:YES completion: nil];
 }
 
 RCT_EXPORT_METHOD(shareOnFacebook:(NSDictionary *)options


### PR DESCRIPTION
This just removes the `if isAvailableForServiceType` check

If the service type is not available, the dialog will explain what's going on and prompt the user to add one or let them cancel. If we don't open the share dialog just because an account hasn't been added yet, then every app has to build a separate thing that points the user at settings where they can add an account... 

Really seems like using the standard dialog like this should be the default and that people can check `isAvailableForServiceType` on their own if they want to show a custom dialog.