### PR TITLE
Fix Twitter sharing on Android

### DIFF
--- a/android/src/main/java/com/barefootcoders/android/react/KDSocialShare/KDSocialShareModule.java
+++ b/android/src/main/java/com/barefootcoders/android/react/KDSocialShare/KDSocialShareModule.java
@@ -45,6 +45,8 @@ public class KDSocialShareModule extends ReactContextBaseJavaModule {
         Uri uri = Uri.parse(tweetUrl);
         shareIntent = new Intent(Intent.ACTION_VIEW, uri);
       }
+      
+      shareIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
       reactContext.startActivity(shareIntent);
     } catch (Exception ex) {
       callback.invoke("error");

--- a/android/src/main/java/com/barefootcoders/android/react/KDSocialShare/KDSocialShareModule.java
+++ b/android/src/main/java/com/barefootcoders/android/react/KDSocialShare/KDSocialShareModule.java
@@ -33,21 +33,20 @@ public class KDSocialShareModule extends ReactContextBaseJavaModule {
   public void tweet(ReadableMap options, Callback callback) {
     try {
       String shareText = options.getString("text");
-      Intent shareIntent;
 
       if (doesPackageExist("com.twitter.android")) {
-        shareIntent = new Intent(Intent.ACTION_SEND);
-        shareIntent.setClassName("com.twitter.android", "com.twitter.android.PostActivity");
-        shareIntent.setType("text/*");
-        shareIntent.putExtra(android.content.Intent.EXTRA_TEXT, shareText);
+        try {
+          tweetViaTwitterComposerClass(shareText);
+        } catch (Exception ex1) {
+          try {
+            tweetViaTwitterDefaultClass(shareText);
+          } catch (Exception ex2) {
+            tweetViaWebPopup(shareText);
+          }
+        }
       } else {
-        String tweetUrl = "https://twitter.com/intent/tweet?text=" + shareText;
-        Uri uri = Uri.parse(tweetUrl);
-        shareIntent = new Intent(Intent.ACTION_VIEW, uri);
+        tweetViaWebPopup(shareText);
       }
-      
-      shareIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
-      reactContext.startActivity(shareIntent);
     } catch (Exception ex) {
       callback.invoke("error");
     }
@@ -93,5 +92,31 @@ public class KDSocialShareModule extends ReactContextBaseJavaModule {
        return false;
      }
      return true;
+  }
+
+  private void tweetViaTwitterComposerClass(String shareText) throws Exception {
+    Intent shareIntent = new Intent(Intent.ACTION_SEND);
+    shareIntent.setClassName("com.twitter.android", "com.twitter.android.composer.ComposerActivity");
+    shareIntent.setType("text/*");
+    shareIntent.putExtra(android.content.Intent.EXTRA_TEXT, shareText);
+    shareIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    reactContext.startActivity(shareIntent);
+  }
+
+  private void tweetViaTwitterDefaultClass(String shareText) throws Exception {
+    Intent shareIntent = new Intent(Intent.ACTION_SEND);
+    shareIntent.setPackage("com.twitter.android");
+    shareIntent.setType("text/*");
+    shareIntent.putExtra(android.content.Intent.EXTRA_TEXT, shareText);
+    shareIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    reactContext.startActivity(shareIntent);
+  }
+
+  private void tweetViaWebPopup(String shareText) throws Exception {
+    String tweetUrl = "https://twitter.com/intent/tweet?text=" + shareText;
+    Uri uri = Uri.parse(tweetUrl);
+    Intent shareIntent = new Intent(Intent.ACTION_VIEW, uri);
+    shareIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+    reactContext.startActivity(shareIntent);
   }
 }


### PR DESCRIPTION
This PR attempts to fix issues with sharing via Twitter on Android.

It didn't work because of 2 errors:
- "calling startActivity() from outside of an Activity context" error because of missing `FLAG_ACTIVITY_NEW_TASK` flag. Adding the following line before starting the intent fixes the issue.
```android
shareIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
```
- The default class for Twitter intent has changed and `"com.twitter.android.PostActivity"` no longer works. I updated it to `"com.twitter.android.composer.ComposerActivity"` and also add a fall back to use the default class of the `"com.twitter.android"` package. If it still fails, we just create an intent with a Twitter url.