### PR TITLE
Fix breaking change for RN 0.47

### DIFF
--- a/android/src/main/java/com/barefootcoders/android/react/KDSocialShare/KDSocialShare.java
+++ b/android/src/main/java/com/barefootcoders/android/react/KDSocialShare/KDSocialShare.java
@@ -25,11 +25,6 @@ public class KDSocialShare implements ReactPackage {
     }
 
     @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-    @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Collections.emptyList();
     }


### PR DESCRIPTION
Removed reference to createJSModules() which breaks Android builds. 

See [facebook/react-native@ce6fb33](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8)