### PR TITLE
Resolve Android RN 0.47 breaking change

### DIFF
--- a/android/src/main/java/com/barefootcoders/android/react/KDSocialShare/KDSocialShare.java
+++ b/android/src/main/java/com/barefootcoders/android/react/KDSocialShare/KDSocialShare.java
@@ -29,7 +29,7 @@ public class KDSocialShare implements ReactPackage {
         return Collections.emptyList();
     }
 
-    @Override
+    // Deprecated from RN 0.47.0
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
facebook/react-native@ce6fb33

Keep method for backward-compatibility but remove `@Override` for RN 0.47 and up.