### PR TITLE
Use Android Uri.encode when constructing URIs with query params

### DIFF
--- a/android/src/main/java/com/barefootcoders/android/react/KDSocialShare/KDSocialShareModule.java
+++ b/android/src/main/java/com/barefootcoders/android/react/KDSocialShare/KDSocialShareModule.java
@@ -64,7 +64,7 @@ public class KDSocialShareModule extends ReactContextBaseJavaModule {
         shareIntent.putExtra(Intent.EXTRA_TEXT, shareText);
       } else if (options.hasKey("link")) {
         String shareUrl = options.getString("link");
-        String sharerUrl = "https://www.facebook.com/sharer/sharer.php?u=" + shareUrl;
+        String sharerUrl = "https://www.facebook.com/sharer/sharer.php?u=" + Uri.encode(shareUrl);
         shareIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(sharerUrl));
       } else {
         if (options.hasKey("text") && !doesPackageExist("com.facebook.katana")) {
@@ -113,7 +113,7 @@ public class KDSocialShareModule extends ReactContextBaseJavaModule {
   }
 
   private void tweetViaWebPopup(String shareText) throws Exception {
-    String tweetUrl = "https://twitter.com/intent/tweet?text=" + shareText;
+    String tweetUrl = "https://twitter.com/intent/tweet?text=" + Uri.encode(shareText);
     Uri uri = Uri.parse(tweetUrl);
     Intent shareIntent = new Intent(Intent.ACTION_VIEW, uri);
     shareIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);


### PR DESCRIPTION
Firstly, solid library 👍 

Quick enhancement: encode strings on the Android side before using them as query params. Without properly encoding query parameters in the twitter fallback for example on android, you get a `URISyntaxException` error like this if you share a message with invalid characters (e.g. another URL in it):

**Error without fix:**

![Error withrout fix](https://d.pr/i/FXVQdE.png)

**With fix:**

![After fix](https://d.pr/i/y4Z5Wq.png)

Note: trying to encode it ahead of time in JS using `encodeURIComponent` works for the fallback case but breaks the case where the user has the app installed (they get a garbled URI-encoded string in the share box -- at least on twitter).

Cheers!