### PR TITLE
[iOS] check app availability by URL scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ Let me know how it works.
 4. Go to `node_modules` ➜ `react-native-social-share`➜ iOS and add `KDSocialShare.h` and `KDSocialShare.m` 
 5. Go to your project's `Build Phases` ➜ `Link Binary With Libraries` phase
 6. Add `Social.framework` to ➜ `Link Binary With Libraries` build phase of your project (click the '+' and search for 'social').
-7. Run your project (`Cmd+R`)
+7. Add 'LSApplicationQueriesSchemes' key (Type: Array) with items (Type: String) 'fb' and 'twitter'  to `Info.plist` of your project 
+8. Run your project (`Cmd+R`)
 
 Now you can implement the share popups in your react native code.
 

--- a/iOS/KDSocialShare.m
+++ b/iOS/KDSocialShare.m
@@ -24,11 +24,6 @@ RCT_EXPORT_MODULE()
      options:(NSDictionary *)options
     callback:(RCTResponseSenderBlock)callback
 {
-  if (![SLComposeViewController isAvailableForServiceType:serviceType]) {
-    callback(@[@"not_available"]);
-    return;
-  }
-
   SLComposeViewController *composeCtl = [SLComposeViewController composeViewControllerForServiceType:serviceType];
 
   if ([options objectForKey:@"link"] && [options objectForKey:@"link"] != [NSNull null]) {
@@ -67,13 +62,23 @@ RCT_EXPORT_MODULE()
 RCT_EXPORT_METHOD(shareOnFacebook:(NSDictionary *)options
                   callback: (RCTResponseSenderBlock)callback)
 {
-  [self share:SLServiceTypeFacebook options:options callback: callback];
+    NSURL *url = [NSURL URLWithString:@"fb://"];
+    if ([[UIApplication sharedApplication] canOpenURL:url]) {
+        [self share:SLServiceTypeFacebook options:options callback: callback];
+    } else {
+        callback(@[@"not_available"]);
+    }
 }
 
 RCT_EXPORT_METHOD(tweet:(NSDictionary *)options
                   callback: (RCTResponseSenderBlock)callback)
 {
-  [self share:SLServiceTypeTwitter options:options callback: callback];
+    NSURL *url = [NSURL URLWithString:@"twitter://"];
+    if ([[UIApplication sharedApplication] canOpenURL:url]) {
+        [self share:SLServiceTypeTwitter options:options callback: callback];
+    } else {
+        callback(@[@"not_available"]);
+    }
 }
 
 @end


### PR DESCRIPTION
fixed https://github.com/doefler/react-native-social-share/issues/60

- To avoid "not_available" issue on iOS 11, check app availability by url scheme instead of using `SLComposeViewController isAvailableForServiceType` method.
- Added how to setup to README .