### PR TITLE
Android API 26+ compatibility resolving.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,18 @@
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext;
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 26;
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '26.0.3';
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16;
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 26;
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 2
         versionName "1.1"
         ndk {


### PR DESCRIPTION
This change make it able to use this library for Android SDK 26 and higher without issues when Gradle wrapper does.