### PR TITLE
Use `implementation` instead of `compile`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,5 +25,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
+    implementation 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
Support for gradle 3.+.
Use `implementation` instead of `compile` in build.gradle.