### PR TITLE
Fix #74 shareOnFacebook returns error on Android 9.0

### DIFF
--- a/android/src/main/java/com/barefootcoders/android/react/KDSocialShare/KDSocialShareModule.java
+++ b/android/src/main/java/com/barefootcoders/android/react/KDSocialShare/KDSocialShareModule.java
@@ -63,14 +63,14 @@ public class KDSocialShareModule extends ReactContextBaseJavaModule {
         shareIntent = new Intent(Intent.ACTION_SEND);
         shareIntent.setType("text/plain");
         shareIntent.putExtra(Intent.EXTRA_TEXT, shareText);
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M || Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
           shareIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         }
       } else if (options.hasKey("link")) {
         String shareUrl = options.getString("link");
         String sharerUrl = "https://www.facebook.com/sharer/sharer.php?u=" + Uri.encode(shareUrl);
         shareIntent = new Intent(Intent.ACTION_VIEW, Uri.parse(sharerUrl));
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M) {
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.M || Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
           shareIntent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         }
       } else {


### PR DESCRIPTION
fix https://github.com/doefler/react-native-social-share/issues/74

Set `FLAG_ACTIVITY_NEW_TASK` for shareIntent (Android 9).

FYI: https://developer.android.com/about/versions/pie/android-9.0-changes-all#fant-required

> With Android 9, you cannot start an activity from a non-activity context unless you pass the intent flag FLAG_ACTIVITY_NEW_TASK. If you attempt to start an activity without passing this flag, the activity does not start, and the system prints a message to the log.